### PR TITLE
Adding dependabot configs and automated updates.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,20 @@
+version: 1
+
+  - package_manager: "php:composer"
+    directory: "/application"
+    update_schedule: "daily"
+    target_branch: "automated_updates"
+    version_requirement_updates: "auto"
+
+  - package_manager: "javascript"
+    directory: "/application"
+    update_schedule: "daily"
+    target_branch: "automated_updates"
+    version_requirement_updates: "auto"
+
+  - package_manager: "docker"
+    direcotry: "/"
+    update_schedule: "daily"
+    target_branch: "automated_updates"
+
+


### PR DESCRIPTION
Adding Dependabot as an experiment.

## Description

Set up an `automated_updates` branch for the Dependabot to check and make pull requests against.  These updates can be applied auotmatically to the branch, and then a weekly version bump branch can be cut from `automated_updates` and a PR can be opened against `master`.  

## Motivation and context

This is an experiment in service of setting up automated updates workflows for Stanford Web Services.


If it fixes an open issue, please link to the issue here (if you write `fixes #num`
or `closes #num`, the issue will be automatically closed when the pull is accepted.)

## How has this been tested?

These changes are minimal and only affect the dependabot config.  Automated updates will happen in 

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [ X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ X] My pull request addresses exactly one patch/feature.
- [ X] I have created a branch for this patch/feature.
- [ X] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
